### PR TITLE
Get fancy quotes “..” ‘..’ ”..” and #`{{ and #`{{ and #`｢ working and qx[] Qx[] Qw fixes

### DIFF
--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -363,6 +363,23 @@
     ]
   }
   {
+    'begin': '(?<=\\W|^)‘'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.perl6fe'
+    'end': '’'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.perl6fe'
+    'name': 'string.quoted.single.perl6fe'
+    'patterns': [
+      {
+        'match': '\\\\[‘’\\\\]'
+        'name': 'constant.character.escape.perl6fe'
+      }
+    ]
+  }
+  {
     'begin': '"'
     'beginCaptures':
       '0':
@@ -397,7 +414,7 @@
     'name': 'string.quoted.double.perl6fe'
     'patterns': [
       {
-        'match': '\\\\[abtnfre"\\\\\\{\\}]'
+        'match': '\\\\[abtnfre“”\\\\\\{\\}]'
         'name': 'constant.character.escape.perl6fe'
       }
       {
@@ -420,7 +437,7 @@
     'name': 'string.quoted.double.perl6fe'
     'patterns': [
       {
-        'match': '\\\\[abtnfre"\\\\\\{\\}]'
+        'match': '\\\\[abtnfre”“\\\\\\{\\}]'
         'name': 'constant.character.escape.perl6fe'
       }
       {
@@ -431,6 +448,7 @@
       }
     ]
   }
+
   {
     'include': '#shellquotes'
   }

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -509,7 +509,7 @@
     'contentName': 'string.quoted.q.double.angle.perl6fe'
     'patterns': [
       {
-        'include': '#qq_angle_string_content'
+        'include': '#q_angle_string_content'
       }
     ]
   }
@@ -538,7 +538,7 @@
     'contentName': 'string.quoted.q.double.paren.perl6fe'
     'patterns': [
       {
-        'include': '#qq_paren_string_content'
+        'include': '#q_paren_string_content'
       }
     ]
   }
@@ -567,7 +567,7 @@
     'contentName': 'string.quoted.q.double.bracket.perl6fe'
     'patterns': [
       {
-        'include': '#qq_bracket_string_content'
+        'include': '#q_bracket_string_content'
       }
     ]
   }
@@ -625,7 +625,7 @@
     'contentName': 'string.quoted.q.single.angle.perl6fe'
     'patterns': [
       {
-        'include': '#qq_angle_string_content'
+        'include': '#q_angle_string_content'
       }
     ]
   }
@@ -654,7 +654,7 @@
     'contentName': 'string.quoted.q.single.slash.perl6fe'
     'patterns': [
       {
-        'include': '#qq_slash_string_content'
+        'include': '#q_slash_string_content'
       }
     ]
   }
@@ -683,7 +683,7 @@
     'contentName': 'string.quoted.q.single.paren.perl6fe'
     'patterns': [
       {
-        'include': '#qq_paren_string_content'
+        'include': '#q_paren_string_content'
       }
     ]
   }
@@ -712,7 +712,7 @@
     'contentName': 'string.quoted.q.single.bracket.perl6fe'
     'patterns': [
       {
-        'include': '#qq_bracket_string_content'
+        'include': '#q_bracket_string_content'
       }
     ]
   }
@@ -741,7 +741,7 @@
     'contentName': 'string.quoted.q.single.apostrophe.perl6fe'
     'patterns': [
       {
-        'include': '#qq_single_string_content'
+        'include': '#q_single_string_content'
       }
     ]
   }
@@ -770,7 +770,7 @@
     'contentName': 'string.quoted.q.single.quote.perl6fe'
     'patterns': [
       {
-        'include': '#qq_double_string_content'
+        'include': '#q_double_string_content'
       }
     ]
   }
@@ -1191,7 +1191,7 @@
           'patterns': [
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
             }
           ]
         }
@@ -1210,7 +1210,7 @@
           'patterns': [
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
 
             }
           ]
@@ -1230,7 +1230,7 @@
           'patterns': [
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
             }
           ]
         }
@@ -1249,7 +1249,7 @@
           'patterns': [
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
             }
           ]
         }
@@ -1268,7 +1268,7 @@
           'patterns': [
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
             }
           ]
         }
@@ -1291,7 +1291,7 @@
             }
             {
               'include': 'source.shell'
-              'include': '#qq_single_string_content'
+              'include': '#q_single_string_content'
             }
           ]
         }
@@ -1618,7 +1618,7 @@
             'include': '#p5_escaped_char'
           }
           {
-            'include': '#qq_bracket_string_content'
+            'include': '#q_bracket_string_content'
           }
         ]
       }
@@ -1649,7 +1649,7 @@
             'include': '#p5_escaped_char'
           }
           {
-            'include': '#qq_slash_string_content'
+            'include': '#q_slash_string_content'
           }
         ]
       }
@@ -1777,12 +1777,12 @@
         'name': 'meta.interpolation.perl6fe'
       }
     ]
-  'qq_angle_string_content':
+  'q_angle_string_content':
     'begin': '<'
     'end': '>'
     'patterns': [
       {
-        'include': '#qq_angle_string_content'
+        'include': '#q_angle_string_content'
       }
     ]
   'q_brace_string_content':
@@ -1793,43 +1793,43 @@
         'include': '#q_brace_string_content'
       }
     ]
-  'qq_bracket_string_content':
+  'q_bracket_string_content':
     'begin': '\\['
     'end': '\\]'
     'patterns': [
       {
-        'include': '#qq_bracket_string_content'
+        'include': '#q_bracket_string_content'
       }
     ]
-  'qq_double_string_content':
+  'q_double_string_content':
     'begin': '\"'
     'end': '\"'
     'patterns': [
       {
-        'include': '#qq_double_string_content'
+        'include': '#q_double_string_content'
       }
     ]
-  'qq_paren_string_content':
+  'q_paren_string_content':
     'begin': '\\('
     'end': '\\)'
     'patterns': [
       {
-        'include': '#qq_paren_string_content'
+        'include': '#q_paren_string_content'
       }
     ]
-  'qq_single_string_content':
+  'q_single_string_content':
     'begin': '\''
     'end': '\''
     'patterns': [
       {
-        'include': '#qq_single_string_content'
+        'include': '#q_single_string_content'
       }
     ]
-  'qq_slash_string_content':
+  'q_slash_string_content':
     'begin': '\\\\/'
     'end': '\\\\/'
     'patterns': [
       {
-        'include': '#qq_slash_string_content'
+        'include': '#q_slash_string_content'
       }
     ]

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -71,6 +71,18 @@
     ]
   }
   {
+    'begin': '#`\\(\\(',
+    'end': '\\)\\)',
+    'name': 'comment.multiline.hash-tick.doubleparens.perl6fe'
+    'patterns': [
+      {
+        'begin': '\\(\\('
+        'end': '\\)\\)'
+        'name': 'comment.internal.doubleparens.perl6fe'
+      }
+    ]
+  }
+  {
     'begin': '#`\\[',
     'end': '\\]',
     'name': 'comment.multiline.hash-tick.brackets.perl6fe'
@@ -97,24 +109,36 @@
   {
     'begin': '#`\\{\\{',
     'end': '\\}\\}',
-    'name': 'comment.multiline.hash-tick.braces.perl6fe'
+    'name': 'comment.multiline.hash-tick.doublebraces.perl6fe'
     'patterns': [
       {
         'begin': '\\{\\{'
         'end': '\\}\\}'
-        'name': 'comment.internal.braces.perl6fe'
+        'name': 'comment.internal.doublebraces.perl6fe'
       }
     ]
   }
   {
     'begin': '#`\\「',
     'end': '\\」',
-    'name': 'comment.multiline.hash-tick.perl6fe'
+    'name': 'comment.multiline.hash-tick.fwcornerbracket.perl6fe'
     'patterns': [
       {
         'begin': '\\「'
         'end': '\\」'
-        'name': 'comment.internal.parens.perl6fe'
+        'name': 'comment.internal.fwcornerbracket.perl6fe'
+      }
+    ]
+  }
+  {
+    'begin': '#`\\｢',
+    'end': '\\｣',
+    'name': 'comment.multiline.hash-tick.hwcornerbracket.perl6fe'
+    'patterns': [
+      {
+        'begin': '\\｢'
+        'end': '\\｣'
+        'name': 'comment.internal.hwcornerbracket.perl6fe'
       }
     ]
   }

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -480,7 +480,7 @@
     'contentName': 'string.quoted.q.double.brace.perl6fe'
     'patterns': [
       {
-        'include': '#qq_brace_string_content'
+        'include': '#q_brace_string_content'
       }
     ]
   }
@@ -596,7 +596,7 @@
     'contentName': 'string.quoted.q.single.brace.perl6fe'
     'patterns': [
       {
-        'include': '#qq_brace_string_content'
+        'include': '#q_brace_string_content'
       }
     ]
   }
@@ -1587,7 +1587,7 @@
             'include': '#p5_escaped_char'
           }
           {
-            'include': '#qq_brace_string_content'
+            'include': '#q_brace_string_content'
           }
         ]
       }
@@ -1785,12 +1785,12 @@
         'include': '#qq_angle_string_content'
       }
     ]
-  'qq_brace_string_content':
+  'q_brace_string_content':
     'begin': '{'
     'end': '}'
     'patterns': [
       {
-        'include': '#qq_brace_string_content'
+        'include': '#q_brace_string_content'
       }
     ]
   'qq_bracket_string_content':

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -357,7 +357,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -386,7 +386,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -415,7 +415,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -444,7 +444,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -473,7 +473,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -502,7 +502,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -531,7 +531,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -560,7 +560,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -589,7 +589,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -618,7 +618,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -647,7 +647,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -409,6 +409,29 @@
     ]
   }
   {
+    'begin': '”'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.perl6fe'
+    'end': '”'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.perl6fe'
+    'name': 'string.quoted.double.perl6fe'
+    'patterns': [
+      {
+        'match': '\\\\[abtnfre"\\\\\\{\\}]'
+        'name': 'constant.character.escape.perl6fe'
+      }
+      {
+        'include': '#interpolation'
+      }
+      {
+        'include': '#special_variables'
+      }
+    ]
+  }
+  {
     'include': '#shellquotes'
   }
   {

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -363,11 +363,34 @@
     ]
   }
   {
-    'begin': '"|“'
+    'begin': '"'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.perl6fe'
-    'end': '"|”'
+    'end': '"'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.string.end.perl6fe'
+    'name': 'string.quoted.double.perl6fe'
+    'patterns': [
+      {
+        'match': '\\\\[abtnfre"\\\\\\{\\}]'
+        'name': 'constant.character.escape.perl6fe'
+      }
+      {
+        'include': '#interpolation'
+      }
+      {
+        'include': '#special_variables'
+      }
+    ]
+  }
+  {
+    'begin': '“'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.string.begin.perl6fe'
+    'end': '”'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.perl6fe'

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -1159,7 +1159,7 @@
   'shellquotes':
     'patterns': [
         {
-          'begin': '(qx)\\s*({{)'
+          'begin': '([qQ]x)\\s*({{)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1173,11 +1173,12 @@
           'patterns': [
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
             }
           ]
         }
         {
-          'begin': '(qx)\\s*({)'
+          'begin': '([qQ]x)\\s*({)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1191,11 +1192,13 @@
           'patterns': [
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
+
             }
           ]
         }
         {
-          'begin': '(qx)\\s*(\\[\\[)'
+          'begin': '([qQ]x)\\s*(\\[\\[)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1209,11 +1212,12 @@
           'patterns': [
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
             }
           ]
         }
         {
-          'begin': '(qx)\\s*(\\[)'
+          'begin': '([Qq]x)\\s*(\\[)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1227,11 +1231,12 @@
           'patterns': [
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
             }
           ]
         }
         {
-          'begin': '(qx)\\s*(\\|)'
+          'begin': '([Qq]x)\\s*(\\|)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1245,11 +1250,12 @@
           'patterns': [
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
             }
           ]
         }
         {
-          'begin': '(qx)\\s*(\\/)'
+          'begin': '([Qq]x)\\s*(\\/)'
           'beginCaptures':
             '1':
               'name': 'string.quoted.q.shell.operator.perl6fe'
@@ -1267,6 +1273,7 @@
             }
             {
               'include': 'source.shell'
+              'include': '#qq_single_string_content'
             }
           ]
         }

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -363,11 +363,11 @@
     ]
   }
   {
-    'begin': '"'
+    'begin': '"|“'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.perl6fe'
-    'end': '"'
+    'end': '"|”'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.perl6fe'

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -59,18 +59,6 @@
     'name': 'meta.documentation.block.declarator.perl6fe'
   }
   {
-    'begin': '#`\\(',
-    'end': '\\)',
-    'name': 'comment.multiline.hash-tick.parens.perl6fe'
-    'patterns': [
-      {
-        'begin': '\\('
-        'end': '\\)'
-        'name': 'comment.internal.parens.perl6fe'
-      }
-    ]
-  }
-  {
     'begin': '#`\\(\\(',
     'end': '\\)\\)',
     'name': 'comment.multiline.hash-tick.doubleparens.perl6fe'
@@ -79,6 +67,18 @@
         'begin': '\\(\\('
         'end': '\\)\\)'
         'name': 'comment.internal.doubleparens.perl6fe'
+      }
+    ]
+  }
+  {
+    'begin': '#`\\(',
+    'end': '\\)',
+    'name': 'comment.multiline.hash-tick.parens.perl6fe'
+    'patterns': [
+      {
+        'begin': '\\('
+        'end': '\\)'
+        'name': 'comment.internal.parens.perl6fe'
       }
     ]
   }
@@ -95,18 +95,6 @@
     ]
   }
   {
-    'begin': '#`\\{',
-    'end': '\\}',
-    'name': 'comment.multiline.hash-tick.braces.perl6fe'
-    'patterns': [
-      {
-        'begin': '\\{'
-        'end': '\\}'
-        'name': 'comment.internal.braces.perl6fe'
-      }
-    ]
-  }
-  {
     'begin': '#`\\{\\{',
     'end': '\\}\\}',
     'name': 'comment.multiline.hash-tick.doublebraces.perl6fe'
@@ -115,6 +103,18 @@
         'begin': '\\{\\{'
         'end': '\\}\\}'
         'name': 'comment.internal.doublebraces.perl6fe'
+      }
+    ]
+  }
+  {
+    'begin': '#`\\{',
+    'end': '\\}',
+    'name': 'comment.multiline.hash-tick.braces.perl6fe'
+    'patterns': [
+      {
+        'begin': '\\{'
+        'end': '\\}'
+        'name': 'comment.internal.braces.perl6fe'
       }
     ]
   }

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -439,7 +439,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -468,7 +468,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -497,7 +497,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -526,7 +526,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -555,7 +555,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -584,7 +584,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -613,7 +613,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -642,7 +642,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -671,7 +671,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -700,7 +700,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
@@ -729,7 +729,7 @@
   }
   {
     'begin': '(?x)
-      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q|Qw)
+      (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
           x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -460,7 +460,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -489,7 +489,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -518,7 +518,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -547,7 +547,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -576,7 +576,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -605,7 +605,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -634,7 +634,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -663,7 +663,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -692,7 +692,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -721,7 +721,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )
@@ -750,7 +750,7 @@
       (q{1,2}(?:x|w|ww|v|s|a|h|f|c|b|p)?|Q(?:x|w|ww|v|s|a|h|f|c|b|p)?)
       ((?:
         \\s*:(?:
-          x|exec|w|words|ww|quotewords|v|val|q|single|qq|double|
+          x|exec|w|words|ww|quotewords|v|val|q|single|double|
           s|scalar|a|array|h|hash|f|function|c|closure|b|blackslash|
           regexp|substr|trans|codes|p|path
         )

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -881,7 +881,7 @@
   }
   {
     'match': '(?x)\\b(?<![\\-:])(
-       take|do|when|next|last|redo|return
+       take|do|when|next|last|redo|return|return-rw
       |contend|maybe|defer|default|exit
       |make|made|continue|break|goto|leave|supply
       |async|lift|await|start|react|whenever

--- a/grammars/perl6fe.cson
+++ b/grammars/perl6fe.cson
@@ -95,6 +95,18 @@
     ]
   }
   {
+    'begin': '#`\\{\\{',
+    'end': '\\}\\}',
+    'name': 'comment.multiline.hash-tick.braces.perl6fe'
+    'patterns': [
+      {
+        'begin': '\\{\\{'
+        'end': '\\}\\}'
+        'name': 'comment.internal.braces.perl6fe'
+      }
+    ]
+  }
+  {
     'begin': '#`\\「',
     'end': '\\」',
     'name': 'comment.multiline.hash-tick.perl6fe'


### PR DESCRIPTION
## Quoting:
* Left double quote Right double quote ```“…”```
* Right double quote Right double quote ```”…”```
* Left single quote Right single quote ```‘…’```
### Qx and qx:
* `qx[]` and `Qx[]` used to syntax highlight variables. Now they highlight like `Q[]` and `q[]`
* `Q|w|ww|v|s|a|h|f|c|b|p` now highlight properly.
## Multi line comments:
* Get these working:  ```#`{{``` and ```#`((``` and ```#`｢```

## Other
* Highlight `return-rw`

Your comments are appreciated.
Pictures attached. 
Before:
![screenshot_20161116_201744](https://cloud.githubusercontent.com/assets/20145557/20376632/389fd918-ac3d-11e6-9ca3-70c31c7ca14d.png)
After:
![screenshot_20161116_203046](https://cloud.githubusercontent.com/assets/20145557/20376633/389ff718-ac3d-11e6-893c-2e501dd7bdfd.png)